### PR TITLE
small fix work with replycode

### DIFF
--- a/common/src/actions/to_mta_only.rs
+++ b/common/src/actions/to_mta_only.rs
@@ -140,8 +140,8 @@ const REPLY_CODE_LENGTH: usize = 3;
 /// Return this status code to the smtp client
 #[derive(Debug, Clone)]
 pub struct Replycode {
-    rcode: Code,
-    xcode: Code,
+    rcode: RCode,
+    xcode: Option<XCode>,
     message: BytesMut,
 }
 
@@ -151,13 +151,25 @@ impl Replycode {
     /// Create a Replycode
     #[must_use]
     #[allow(clippy::similar_names)]
-    pub fn new<R: Into<Code>, X: Into<Code>>(rcode: R, xcode: X, message: &str) -> Self {
+    pub fn new<R: Into<RCode>, X: Into<XCode>>(rcode: R, xcode: X, message: &str) -> Self {
         let rcode = rcode.into();
-        let xcode = xcode.into();
+        let xcode = Some(xcode.into());
 
         Self {
             rcode,
             xcode,
+            message: BytesMut::from(message.as_bytes()),
+        }
+    }
+
+    /// Create a Replycode without xcode
+    #[allow(clippy::similar_names)]
+    pub fn without_xcode<R: Into<RCode>>(rcode: R, message: &str) -> Self {
+        let rcode = rcode.into();
+
+        Self {
+            rcode,
+            xcode: None,
             message: BytesMut::from(message.as_bytes()),
         }
     }
@@ -170,13 +182,13 @@ impl Replycode {
 
     /// The smtp return code
     #[must_use]
-    pub fn rcode(&self) -> &Code {
+    pub fn rcode(&self) -> &RCode {
         &self.rcode
     }
 
     /// The smtp enhanced return code
     #[must_use]
-    pub fn xcode(&self) -> &Code {
+    pub fn xcode(&self) -> &Option<XCode> {
         &self.xcode
     }
 }
@@ -188,7 +200,7 @@ impl Parsable for Replycode {
     #[allow(clippy::similar_names)]
     fn parse(mut buffer: BytesMut) -> Result<Self, ProtocolError> {
         #[allow(clippy::similar_names)]
-        let Some(rcode) = buffer.delimited(0) else {
+        let Some(rcode) = buffer.delimited(b' ') else {
             return Err(NotEnoughData::new(
                 STAGE_DECODING,
                 "Replycode",
@@ -199,22 +211,9 @@ impl Parsable for Replycode {
             )
             .into());
         };
-        let rcode = Code::parse(rcode)?;
+        let rcode = RCode::parse(rcode)?;
 
-        let Some(xcode) = buffer.delimited(0) else {
-            return Err(NotEnoughData::new(
-                STAGE_DECODING,
-                "Replycode",
-                "Missing nullbyte delimiter after xcode",
-                1,
-                0,
-                buffer,
-            )
-            .into());
-        };
-        let xcode = Code::parse(xcode)?;
-
-        let Some(message) = buffer.delimited(0) else {
+        let Some(raw_message) = buffer.delimited(0) else {
             return Err(NotEnoughData::new(
                 STAGE_DECODING,
                 "Replycode",
@@ -225,6 +224,15 @@ impl Parsable for Replycode {
             )
             .into());
         };
+        let mut xcode = None;
+        let mut message = raw_message;
+
+        if let Some(pos) = message.iter().position(|c| *c == b' ') {
+            if let Ok(code) = XCode::parse(BytesMut::from(message[0..pos].as_ref())) {
+                xcode = Some(code);
+                message = BytesMut::from(&message[pos + 1..]);
+            }
+        }
 
         Ok(Self {
             rcode,
@@ -237,15 +245,21 @@ impl Parsable for Replycode {
 impl Writable for Replycode {
     fn write(&self, buffer: &mut BytesMut) {
         buffer.put_slice(self.rcode.as_bytes());
-        buffer.put_u8(0);
-        buffer.put_slice(self.xcode.as_bytes());
-        buffer.put_u8(0);
+        buffer.put_u8(b' ');
+        if let Some(ref xcode) = self.xcode {
+            buffer.put_slice(xcode.as_bytes());
+            buffer.put_u8(b' ');
+        }
         buffer.put_slice(&self.message);
         buffer.put_u8(0);
     }
 
     fn len(&self) -> usize {
-        self.rcode.len() + 1 + self.xcode.len() + 1 + self.message.len() + 1
+        self.rcode.len()
+            + 1
+            + self.xcode.as_ref().map_or(0, |code| code.len() + 1)
+            + self.message.len()
+            + 1
     }
 
     fn code(&self) -> u8 {
@@ -257,18 +271,18 @@ impl Writable for Replycode {
 }
 
 #[derive(Debug, Clone)]
-pub struct Code {
+pub struct XCode {
     code: [u16; REPLY_CODE_LENGTH],
     bytes: BytesMut,
 }
 
-impl From<[u16; REPLY_CODE_LENGTH]> for Code {
+impl From<[u16; REPLY_CODE_LENGTH]> for XCode {
     fn from(code: [u16; REPLY_CODE_LENGTH]) -> Self {
         Self::new(code)
     }
 }
 
-impl Code {
+impl XCode {
     pub fn new(code: [u16; REPLY_CODE_LENGTH]) -> Self {
         Self {
             code,
@@ -329,15 +343,72 @@ impl Code {
         self.bytes.len()
     }
 }
+#[derive(Debug, Clone)]
+pub struct RCode {
+    code: [u8; REPLY_CODE_LENGTH],
+    bytes: BytesMut,
+}
+
+impl From<[u8; REPLY_CODE_LENGTH]> for RCode {
+    fn from(code: [u8; REPLY_CODE_LENGTH]) -> Self {
+        Self::new(code)
+    }
+}
+
+impl RCode {
+    pub fn new(code: [u8; REPLY_CODE_LENGTH]) -> Self {
+        Self {
+            code,
+            bytes: BytesMut::from_iter(code.iter().map(ToString::to_string).join("").as_bytes()),
+        }
+    }
+
+    fn parse(buffer: BytesMut) -> Result<Self, InvalidData> {
+        if buffer.len() < REPLY_CODE_LENGTH {
+            return Err(InvalidData {
+                msg: "Invalid length of code",
+                offending_bytes: buffer,
+            });
+        }
+        let mut code: [u8; 3] = [0_u8; REPLY_CODE_LENGTH];
+        for (pos, c_code) in code.iter_mut().enumerate() {
+            let Ok(number) = String::from_utf8_lossy(&[buffer[pos]]).parse::<u8>() else {
+                return Err(InvalidData {
+                    msg: "invalid u8 in code",
+                    offending_bytes: buffer,
+                });
+            };
+            *c_code = number;
+        }
+        Ok(Self {
+            code,
+            bytes: buffer,
+        })
+    }
+
+    /// The status code
+    #[must_use]
+    pub fn code(&self) -> [u8; REPLY_CODE_LENGTH] {
+        self.code
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    fn len(&self) -> usize {
+        self.bytes.len()
+    }
+}
 
 #[cfg(test)]
 mod test {
     use super::*;
 
     #[test]
-    fn test_rcode_valid() {
+    fn test_xcode_valid() {
         let input = BytesMut::from_iter(b"1.20.3");
-        let code = Code::parse(input).expect("Failed parsing input");
+        let code = XCode::parse(input).expect("Failed parsing input");
 
         assert_eq!(code.code, [1, 20, 3]);
 
@@ -346,8 +417,66 @@ mod test {
     }
 
     #[test]
-    fn test_rcode_invalid() {
+    fn test_xcode_invalid() {
         let input = BytesMut::from_iter(b"1.23");
-        let _code = Code::parse(input).expect_err("Parsing did not error on invalid");
+        let _code = XCode::parse(input).expect_err("Parsing did not error on invalid");
+    }
+
+    #[test]
+    fn test_rcode_valid() {
+        let input = BytesMut::from_iter(b"454");
+        let code = RCode::parse(input).expect("Failed parsing input");
+
+        assert_eq!(code.code, [4, 5, 4]);
+
+        println!("{:?}", code.bytes);
+        assert_eq!(code.bytes.as_ref(), b"454");
+    }
+
+    #[test]
+    fn test_rcode_invalid() {
+        let input = BytesMut::from_iter(b"4.54");
+        let _code = RCode::parse(input).expect_err("Parsing did not error on invalid");
+    }
+
+    #[test]
+    fn test_reply_parse() {
+        let input = BytesMut::from_iter(b"501 5.7.0 Client initiated Authentication Exchange\0");
+        let reply: Replycode = Parsable::parse(input).expect("Parsing failed");
+        assert_eq!(reply.rcode.as_bytes(), b"501");
+        assert_eq!(reply.xcode.expect("Parsing failed").as_bytes(), b"5.7.0");
+        assert_eq!(reply.message, "Client initiated Authentication Exchange");
+    }
+
+    #[test]
+    fn test_reply_parse_empty_xcode() {
+        let input =
+            BytesMut::from_iter(b"421 Service not available, closing transmission channel\0");
+        let reply: Replycode = Parsable::parse(input).expect("Parsing failed");
+        assert_eq!(reply.rcode.as_bytes(), b"421");
+        assert!(reply.xcode.is_none());
+        assert_eq!(
+            reply.message,
+            "Service not available, closing transmission channel"
+        );
+    }
+
+    #[test]
+    fn test_reply_write() {
+        let input = BytesMut::from_iter(b"501 5.7.0 Client initiated Authentication Exchange\0");
+        let reply: Replycode = Parsable::parse(input.clone()).expect("Parsing failed");
+        let mut output = BytesMut::new();
+        reply.write(&mut output);
+        assert_eq!(output.as_ref(), input.as_ref());
+    }
+
+    #[test]
+    fn test_reply_write_with_empty_xcode() {
+        let input =
+            BytesMut::from_iter(b"421 Service not available, closing transmission channel\0");
+        let reply: Replycode = Parsable::parse(input.clone()).expect("Parsing failed");
+        let mut output = BytesMut::new();
+        reply.write(&mut output);
+        assert_eq!(output.as_ref(), input.as_ref());
     }
 }


### PR DESCRIPTION
Hi @girstenbrei ,

First of all, thank you for this excellent library — it’s clearly a significant contribution to the Rust ecosystem, and I’m confident the community will greatly benefit from it.

While integrating **miltr** with **Postfix** for mail processing, I encountered the following error in the logs:

`warning: milter inet:127.0.0.1:25026: malformed reply: 4.5.4`

After reviewing the Milter protocol and the library’s source code, I believe I found the cause:

- `RCODE` should be the three-digit SMTP reply code (as per **RFC 821**), e.g., `451`, `551`.
    
- `XCODE` should be the extended status code (as per **RFC 2034**), e.g., `4.7.0`, `5.7.1`. It may be optional, but if included, it must follow a valid `RCODE`.
	
- The '\0' separator should only be used at the end of the message. Spaces should be used elsewhere.
    

So the correct format should be:

`451 4.7.0 Temporary authentication error\0`

But the current response from the library is:

`4.5.4\04.7.0\0Temporary authentication error\0`

This leads Postfix to reject the reply as malformed.

I’ve prepared a small fix for this behavior, tested it with Postfix, and confirmed that it resolves the issue.
Similar code can be found in purepythonmilter library.
I'd be grateful if you would consider merging this improvement.

Thank you again for your work on this project!

Best regards, Igor