### PR TITLE
chore: release v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "miltr-client"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "asynchronous-codec",
  "bitflags 2.4.2",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "miltr-common"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "allocation-counter",
  "assert_matches",
@@ -541,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "miltr-server"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-dropper",
  "async-trait",

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/girstenbrei/miltr/compare/miltr-client-v0.1.1...miltr-client-v0.1.2) - 2025-05-23
+
+### Other
+
+- updated the following local packages: miltr-common
+
 ## [0.1.1](https://github.com/girstenbrei/miltr/compare/miltr-client-v0.1.0...miltr-client-v0.1.1) - 2025-01-26
 
 ### Added

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miltr-client"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 readme = "Readme.md"
 license = "MIT"
@@ -23,7 +23,7 @@ thiserror = "2.0.11"
 asynchronous-codec = "0.7.0"
 bytes = "1.5.0"
 paste = "1.0.14"
-miltr-common = { version = "0.1.1", path = "../common" }
+miltr-common = { version = "0.1.2", path = "../common" }
 miltr-utils = { version = "0.1.1", path = "../utils" }
 tracing = { version = "0.1", default-features = false, features = ["std", "attributes"], optional = true }
 

--- a/common/CHANGELOG.md
+++ b/common/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/girstenbrei/miltr/compare/miltr-common-v0.1.1...miltr-common-v0.1.2) - 2025-05-23
+
+### Fixed
+
+- have replycode postfix compatible ([#9](https://github.com/girstenbrei/miltr/pull/9))
+
 ## [0.1.1](https://github.com/girstenbrei/miltr/compare/miltr-common-v0.1.0...miltr-common-v0.1.1) - 2025-01-26
 
 ### Added

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miltr-common"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 readme = "Readme.md"
 license = "MIT"

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/girstenbrei/miltr/compare/miltr-server-v0.1.1...miltr-server-v0.1.2) - 2025-05-23
+
+### Other
+
+- updated the following local packages: miltr-common
+
 ## [0.1.1](https://github.com/girstenbrei/miltr/compare/miltr-server-v0.1.0...miltr-server-v0.1.1) - 2025-01-26
 
 ### Added

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miltr-server"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 readme = "Readme.md"
 license = "MIT"
@@ -22,7 +22,7 @@ async-trait = "0.1.77"
 asynchronous-codec = "0.7.0"
 bytes = "1.5.0"
 futures = "0.3.30"
-miltr-common = { version = "0.1.1", path = "../common" }
+miltr-common = { version = "0.1.2", path = "../common" }
 miltr-utils = { version = "0.1.1", path = "../utils" }
 thiserror = "2.0.11"
 tracing = { version = "0.1", default-features = false, features = ["std", "attributes"], optional = true }


### PR DESCRIPTION



## 🤖 New release

* `miltr-common`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `miltr-server`: 0.1.1 -> 0.1.2
* `miltr-client`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `miltr-common`

<blockquote>

## [0.1.2](https://github.com/girstenbrei/miltr/compare/miltr-common-v0.1.1...miltr-common-v0.1.2) - 2025-05-23

### Fixed

- have replycode postfix compatible ([#9](https://github.com/girstenbrei/miltr/pull/9))
</blockquote>

## `miltr-server`

<blockquote>

## [0.1.2](https://github.com/girstenbrei/miltr/compare/miltr-server-v0.1.1...miltr-server-v0.1.2) - 2025-05-23

### Other

- updated the following local packages: miltr-common
</blockquote>

## `miltr-client`

<blockquote>

## [0.1.2](https://github.com/girstenbrei/miltr/compare/miltr-client-v0.1.1...miltr-client-v0.1.2) - 2025-05-23

### Other

- updated the following local packages: miltr-common
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).