### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/girstenbrei/miltr/compare/miltr-v0.1.2...miltr-v0.1.3) - 2025-09-19
+
+### Added
+
+- Setup postfix integation tests ([#18](https://github.com/girstenbrei/miltr/pull/18))
+
+### Fixed
+
+- failing client_v_server test ([#20](https://github.com/girstenbrei/miltr/pull/20))
+
+### Other
+
+- Upgrade dependencies ([#21](https://github.com/girstenbrei/miltr/pull/21))
+- Add tarpaulin run to ci ([#15](https://github.com/girstenbrei/miltr/pull/15))
+
 ## [0.1.2](https://github.com/girstenbrei/miltr/compare/miltr-v0.1.1...miltr-v0.1.2) - 2025-05-23
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.3](https://github.com/girstenbrei/miltr/compare/miltr-v0.1.2...miltr-v0.1.3) - 2025-09-19
+## [0.2.0](https://github.com/girstenbrei/miltr/compare/miltr-v0.1.2...miltr-v0.1.3) - 2025-09-19
 
 ### Added
 
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix protocol violation: Respond to SMFIC_ABORT with no response, not SMFIS_CONTINUE ([#22](https://github.com/girstenbrei/miltr/pull/22))
 - failing client_v_server test ([#20](https://github.com/girstenbrei/miltr/pull/20))
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "miltr"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "escargot",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "miltr-server"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "async-fd-lock",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "miltr"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "escargot",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "miltr-client"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "asynchronous-codec",
  "bitflags",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "miltr-common"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "allocation-counter",
  "assert_matches",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "miltr-server"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-fd-lock",
  "async-trait",
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "miltr-utils"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bytes",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miltr"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 readme = "Readme.md"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miltr"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 readme = "Readme.md"
 license = "MIT"

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/girstenbrei/miltr/compare/miltr-client-v0.1.2...miltr-client-v0.1.3) - 2025-09-19
+
+### Fixed
+
+- failing client_v_server test ([#20](https://github.com/girstenbrei/miltr/pull/20))
+
+### Other
+
+- Upgrade dependencies ([#21](https://github.com/girstenbrei/miltr/pull/21))
+- Add tarpaulin run to ci ([#15](https://github.com/girstenbrei/miltr/pull/15))
+
 ## [0.1.2](https://github.com/girstenbrei/miltr/compare/miltr-client-v0.1.1...miltr-client-v0.1.2) - 2025-05-23
 
 ### Other

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miltr-client"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 readme = "Readme.md"
 license = "MIT"
@@ -23,8 +23,8 @@ thiserror = "2.0.16"
 asynchronous-codec = "0.7.0"
 bytes = "1.10.1"
 paste = "1.0.15"
-miltr-common = { version = "0.1.2", path = "../common" }
-miltr-utils = { version = "0.1.1", path = "../utils" }
+miltr-common = { version = "0.1.3", path = "../common" }
+miltr-utils = { version = "0.1.2", path = "../utils" }
 tracing = { version = "0.1", default-features = false, features = ["std", "attributes"], optional = true }
 
 [lints.rust]

--- a/common/CHANGELOG.md
+++ b/common/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/girstenbrei/miltr/compare/miltr-common-v0.1.2...miltr-common-v0.1.3) - 2025-09-19
+
+### Other
+
+- Upgrade dependencies ([#21](https://github.com/girstenbrei/miltr/pull/21))
+- Add tarpaulin run to ci ([#15](https://github.com/girstenbrei/miltr/pull/15))
+
 ## [0.1.2](https://github.com/girstenbrei/miltr/compare/miltr-common-v0.1.1...miltr-common-v0.1.2) - 2025-05-23
 
 ### Fixed

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miltr-common"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 readme = "Readme.md"
 license = "MIT"
@@ -26,7 +26,7 @@ thiserror = "2.0.16"
 asynchronous-codec = "0.7.0"
 bytes = "1.10.1"
 bytecount = "0.6.9"
-miltr-utils = { version = "0.1.1", path = "../utils" }
+miltr-utils = { version = "0.1.2", path = "../utils" }
 strum = { version = "0.27.2", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/girstenbrei/miltr/compare/miltr-server-v0.1.2...miltr-server-v0.1.3) - 2025-09-19
+
+### Added
+
+- Setup postfix integation tests ([#18](https://github.com/girstenbrei/miltr/pull/18))
+
+### Other
+
+- Upgrade dependencies ([#21](https://github.com/girstenbrei/miltr/pull/21))
+- protocol violation - respond to SMFIC_ABORT with no response, not SMFIS_CONTINUE ([#22](https://github.com/girstenbrei/miltr/pull/22))
+- Add tarpaulin run to ci ([#15](https://github.com/girstenbrei/miltr/pull/15))
+
 ## [0.1.2](https://github.com/girstenbrei/miltr/compare/miltr-server-v0.1.1...miltr-server-v0.1.2) - 2025-05-23
 
 ### Other

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.3](https://github.com/girstenbrei/miltr/compare/miltr-server-v0.1.2...miltr-server-v0.1.3) - 2025-09-19
+## [0.2.0](https://github.com/girstenbrei/miltr/compare/miltr-server-v0.1.2...miltr-server-v0.1.3) - 2025-09-19
+
+### Fixed
+
+- Fix protocol violation: Respond to SMFIC_ABORT with no response, not SMFIS_CONTINUE ([#22](https://github.com/girstenbrei/miltr/pull/22))
+
 
 ### Added
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miltr-server"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 readme = "Readme.md"
 license = "MIT"
@@ -22,8 +22,8 @@ async-trait = "0.1.89"
 asynchronous-codec = "0.7.0"
 bytes = "1.10.1"
 futures = "0.3.31"
-miltr-common = { version = "0.1.2", path = "../common" }
-miltr-utils = { version = "0.1.1", path = "../utils" }
+miltr-common = { version = "0.1.3", path = "../common" }
+miltr-utils = { version = "0.1.2", path = "../utils" }
 thiserror = "2.0.16"
 tracing = { version = "0.1", default-features = false, features = ["std", "attributes"], optional = true }
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miltr-server"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 readme = "Readme.md"
 license = "MIT"

--- a/utils/CHANGELOG.md
+++ b/utils/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/girstenbrei/miltr/compare/miltr-utils-v0.1.1...miltr-utils-v0.1.2) - 2025-09-19
+
+### Other
+
+- Upgrade dependencies ([#21](https://github.com/girstenbrei/miltr/pull/21))
+
 ## [0.1.1](https://github.com/girstenbrei/miltr/compare/miltr-utils-v0.1.0...miltr-utils-v0.1.1) - 2025-01-26
 
 ### Added

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miltr-utils"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT"
 description = "A miltr utils library in pure rust"


### PR DESCRIPTION


## 🤖 New release

* `miltr-utils`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `miltr-common`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `miltr-server`: 0.1.2 -> 0.2.0 (✓ API compatible changes)
* `miltr-client`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `miltr`: 0.1.2 -> 0.2.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `miltr-utils`

<blockquote>

## [0.1.2](https://github.com/girstenbrei/miltr/compare/miltr-utils-v0.1.1...miltr-utils-v0.1.2) - 2025-09-19

### Other

- Upgrade dependencies ([#21](https://github.com/girstenbrei/miltr/pull/21))
</blockquote>

## `miltr-common`

<blockquote>

## [0.1.3](https://github.com/girstenbrei/miltr/compare/miltr-common-v0.1.2...miltr-common-v0.1.3) - 2025-09-19

### Other

- Upgrade dependencies ([#21](https://github.com/girstenbrei/miltr/pull/21))
- Add tarpaulin run to ci ([#15](https://github.com/girstenbrei/miltr/pull/15))
</blockquote>

## `miltr-server`

<blockquote>

## [0.1.3](https://github.com/girstenbrei/miltr/compare/miltr-server-v0.1.2...miltr-server-v0.1.3) - 2025-09-19

### Added

- Setup postfix integation tests ([#18](https://github.com/girstenbrei/miltr/pull/18))

### Other

- Upgrade dependencies ([#21](https://github.com/girstenbrei/miltr/pull/21))
- protocol violation - respond to SMFIC_ABORT with no response, not SMFIS_CONTINUE ([#22](https://github.com/girstenbrei/miltr/pull/22))
- Add tarpaulin run to ci ([#15](https://github.com/girstenbrei/miltr/pull/15))
</blockquote>

## `miltr-client`

<blockquote>

## [0.1.3](https://github.com/girstenbrei/miltr/compare/miltr-client-v0.1.2...miltr-client-v0.1.3) - 2025-09-19

### Fixed

- failing client_v_server test ([#20](https://github.com/girstenbrei/miltr/pull/20))

### Other

- Upgrade dependencies ([#21](https://github.com/girstenbrei/miltr/pull/21))
- Add tarpaulin run to ci ([#15](https://github.com/girstenbrei/miltr/pull/15))
</blockquote>

## `miltr`

<blockquote>

## [0.1.3](https://github.com/girstenbrei/miltr/compare/miltr-v0.1.2...miltr-v0.1.3) - 2025-09-19

### Added

- Setup postfix integation tests ([#18](https://github.com/girstenbrei/miltr/pull/18))

### Fixed

- failing client_v_server test ([#20](https://github.com/girstenbrei/miltr/pull/20))

### Other

- Upgrade dependencies ([#21](https://github.com/girstenbrei/miltr/pull/21))
- Add tarpaulin run to ci ([#15](https://github.com/girstenbrei/miltr/pull/15))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).